### PR TITLE
Adjust width of inline form for math inputs to fix overflowing

### DIFF
--- a/public/stylesheets/activity.less
+++ b/public/stylesheets/activity.less
@@ -5,6 +5,6 @@
 
 .answer, .expression-answer {
   form.form-inline {
-    width: 10em;
+    width: 11em;
   }
 }


### PR DESCRIPTION
It should be wider than the sum of min-width of the input and the width of the attempt button. Without this adjustment, it looked like:

![before](http://i.imgur.com/NHFRPoE.png)

After applying the adjustment (with the browser's CSS editor):

![after](http://i.imgur.com/Dxss273.png)

Checked on: Google Chrome, Safari, Firefox on Mac OS X.
