### PR TITLE
Append scrollbars if overflow in math editor

### DIFF
--- a/public/stylesheets/guppy-fixes.scss
+++ b/public/stylesheets/guppy-fixes.scss
@@ -8,3 +8,7 @@
     padding: 6pt;
     max-width: 100%;
 }
+
+#guppy {
+    overflow: auto;
+}


### PR DESCRIPTION
Fixes this bug (#210):
![overflow](https://user-images.githubusercontent.com/38190282/44543455-93a75380-a6dd-11e8-8300-40753e13c13b.png)

Tested only with a browser style injector, not from a server instance.