### PR TITLE
Change style of collapse hint button

### DIFF
--- a/public/stylesheets/hints.scss
+++ b/public/stylesheets/hints.scss
@@ -28,4 +28,7 @@
     /* Sometimes mathjax elements cover up the hint collapse button */
     z-index: 1;
     position: relative;
+    width: 1.75em;
+    height: 1.75em;
+    border-radius: 50%;
 }


### PR DESCRIPTION
![screenshot from 2018-09-06 15-58-08](https://user-images.githubusercontent.com/20409621/45182271-c6c60880-b1ee-11e8-8547-01229bd9ef0e.png)

Tested only with a browser style injector, not from a server instance.
