### PR TITLE
Update package.json for napa command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node app.js",
     "test": "mocha",
-    "install": "napa tchapi/pagedown-bootstrap",
+    "install": "napa https://github.com/tchapi/pagedown-bootstrap",
     "postinstall": "gulp"
   },
   "dependencies": {


### PR DESCRIPTION
npm "install" command references "napa tchapi/pagedown-bootstrap".  The napa command attempts to clone via the git:// protocol, which is failing, perhaps due to the repository now being marked as "Public archive". Switching the napa command to explicitly reference https://github.com/ allows the repo to be cloned.